### PR TITLE
docs: align src readmes with current architecture

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,127 +1,60 @@
 # Source Code Overview
 
-This folder contains the AI Browser Sidebar extension code. It is organized into small, focused modules with clear boundaries and path aliases for easy navigation.
+The `src/` tree contains the entire Browser Sidebar extension.  Modules are split by
+responsibility so background logic, extraction, UI, and data plumbing can evolve
+independently while sharing types and utilities through path aliases (see
+`tsconfig.json`).
 
-## Directory Map
+## Directory map
 
 ```
 src/
-├─ config/       # Central config: models, prompts, slash commands
-├─ content/      # Content script: extraction pipeline + sidebar injection glue
-├─ core/         # Provider protocol helpers (ai/) + engines + extraction utils
-├─ data/         # Zustand stores, Chrome storage wrapper, crypto/masking
-├─ extension/    # MV3 service worker, cache, messaging, tab + sidebar managers
-├─ platform/     # Typed wrappers over Chrome APIs (runtime, tabs, storage, …)
-├─ services/     # High‑level facades (chat, extraction, keys, engine manager)
-├─ shared/       # Cross‑cutting utilities (URL checks/normalization)
-├─ sidebar/      # React Shadow‑DOM UI (components, hooks, styles)
-├─ transport/    # HTTP transports (direct and background‑proxied streaming)
-└─ types/        # Shared TS types (messages, tabs, extraction, providers)
+├─ config/      # Model catalogue, slash commands, and system prompt helpers
+├─ content/     # Content script bootstrap plus per-tab extraction pipeline
+├─ core/        # Provider adapters, engine orchestration, shared extraction utils
+├─ data/        # Zustand stores, Chrome storage wrappers, crypto, API-key storage
+├─ extension/   # MV3 service worker, tab/sidebar lifecycle, proxy + cache layers
+├─ platform/    # Typed wrappers around chrome.* APIs (runtime, storage, tabs, ...)
+├─ services/    # High-level facades for chat, engines, extraction, keys, sessions
+├─ shared/      # Cross-cutting helpers (restricted URL guard, URL normaliser)
+├─ sidebar/     # Shadow-DOM React UI, hooks, contexts, layered styling
+├─ transport/   # Fetch/stream transports and proxy policy helpers
+├─ types/       # Shared TypeScript contracts (messages, tabs, providers, …)
+└─ utils/       # Generic helpers that do not belong to another package yet
 ```
 
-## What Lives Where
-
-### config/
-
-- `models.ts` — Model catalog and helpers (OpenAI, Gemini, OpenRouter, OpenAI‑Compat presets)
-- `systemPrompt.ts` — System prompt text helpers
-- `slashCommands.ts` — Built‑in commands (e.g., summarize, explain, fact‑check, rephrase)
-
-### content/
-
-- `core/` — Document patcher, message handler, sidebar controller
-- `extraction/` — Orchestrator with modes: Readability (default), Raw, Defuddle, Selection
-- `extraction/extractors/` — `readability.ts`, `raw.ts`, `defuddle.ts`
-- `extraction/analyzers/` — Content + metadata analyzers
-- `utils/` — DOM and tab helpers
-
-Key updates (Sep 2025):
-
-- Readability extractor added and set as the default mode
-- Runtime toggle for default extraction mode (see `setDefaultExtractionMode`)
-
-### core/
-
-- `ai/<provider>/` — Stateless request builders, stream processors, error mappers
-- `engine/` — Stateful providers: OpenAI, Gemini, OpenRouter, OpenAI‑Compat
-- `extraction/` — Markdown converter and analyzers used by content pipeline
-
-### data/
-
-- `store/` — In‑memory chat/session stores (no persistence) and a persistent settings store
-- `storage/` — Typed Chrome storage wrapper (+ keys subsystem)
-- `security/` — AES‑GCM utilities and masking helpers
-
-### extension/
-
-- `background/index.ts` — Service worker entry
-- `background/messageHandler.ts` — Typed message registry (PING/PONG, GET_TAB_ID/INFO, GET_ALL_TABS, EXTRACT_TAB_CONTENT, CLEANUP_TAB_CACHE, etc.)
-- `background/sidebarManager.ts` — Per‑tab sidebar lifecycle
-- `background/tabManager.ts` — Tab querying, extraction orchestration + cache
-- `background/cache/TabContentCache.ts` — Session storage TTL cache (5 minutes)
-- `background/queue/ExtractionQueue.ts` — Concurrency‑limited extraction queue
-- `messaging/` — Message helpers, error/response shapes
-
-### platform/
-
-- Chrome API wrappers: `runtime.ts`, `tabs.ts`, `storage.ts`, `messaging.ts`, `ports.ts`, `keepAlive.ts`, `alarms.ts`, `action.ts`, `scripting.ts`
-
-### services/
-
-- `chat/ChatService.ts` — Provider‑agnostic streaming with cancel support
-- `engine/EngineManagerService.ts` — Creates/initializes providers, switches models
-- `extraction/ExtractionService.ts` — Background‑mediated extraction with retries
-- `keys/KeyService.ts` — Encrypted BYOK storage + live validation
-- `session/SessionService.ts` — Session keying and URL normalization helpers
-
-### shared/
-
-- `utils/restrictedUrls.ts` and `utils/urlNormalizer.ts`
-
-### sidebar/
-
-- `ChatPanel.tsx`, `index.tsx`, components/, hooks/, contexts/, styles/
-
-### transport/
-
-- `types.ts`, `DirectFetchTransport.ts`, `BackgroundProxyTransport.ts`, `policy.ts`
-
-### types/
-
-- Message protocol, tabs, extraction, providers, settings, storage, etc.
-
-## Message & Data Flow (High Level)
+## Cross-cutting flow
 
 ```
-User → Sidebar (React) → Services (chat/extraction/keys)
-   ↘                                  ↙
-    Background (service worker) ←→ Content script (page)
-                ↘
-               Transports → AI providers
+Sidebar React UI ──▶ Services (chat / extraction / sessions / keys)
+      │                                │
+      │                                └─▶ Core engines + transports
+      │                                        │
+      ▼                                        ▼
+Chrome messaging ◀──── Extension background ◀── Content script extraction
 ```
 
-## Path Aliases (vite.config.ts)
+* The **content script** (`content/`) mounts the React app, orchestrates
+  extraction (`content/extraction/**`), and exposes typed message handlers for
+  the background worker.
+* The **background service worker** (`extension/`) keeps the sidebar alive per
+  tab, proxies CORS restricted requests, and coordinates extractions via
+  `TabManager`, `ExtractionQueue`, and the `TabContentCache`.
+* **Services** hide chrome/runtime specifics from the UI: `ChatService` streams
+  providers, `EngineManagerService` initialises engines from `config/models.ts`,
+  `ExtractionService` talks to the background worker, `KeyService` encrypts BYOK
+  credentials, and `SessionService` keeps deterministic session keys.
+* **Stores and storage** (`data/`) back the UI with Zustand state, Chrome
+  storage accessors, and hardened API-key persistence/rotation utilities.
 
-- `@` → `src/*`, plus focused aliases like `@sidebar`, `@components`, `@hooks`,
-  `@extension`, `@content`, `@core`, `@data`, `@store`, `@storage`, `@security`,
-  `@platform`, `@services`, `@transport`, `@types`, `@config`, `@shared`.
+## Working in this tree
 
-## Current Highlights (Sep 2025)
-
-- Readability is the default extraction mode; Raw/Defuddle/Selection available
-- Slash commands now include `rephrase` and allow per‑command model override
-- Available models in the UI are gated by saved API keys and compat providers
-- Stream cancel support wired through ChatService and the ChatInput cancel button
-
-## Testing
-
-```bash
-npm test              # All tests
-npm run test:watch    # Watch mode
-npm run test:ui       # Vitest UI
-```
-
-## Security & Privacy
-
-- BYOK only; keys encrypted at rest with AES‑GCM (see `data/security` and `services/keys`)
-- Minimal Chrome permissions; sidebar UI runs in Shadow DOM
+* Prefer the path aliases defined in `tsconfig.json`/`vite.config.ts`
+  (`@content`, `@core`, `@data`, `@services`, `@sidebar`, …) to keep imports
+  stable when files move.
+* Unit and integration tests mirror this layout under `tests/**`; e.g. provider
+  helpers live in `tests/unit/core/ai/`, extraction logic in
+  `tests/unit/content/` and `tests/integration/content/`.
+* New shared types should live in `types/` and be exported through the relevant
+  barrel file so both the background script and UI can consume them without
+  circular deps.

--- a/src/content/README.md
+++ b/src/content/README.md
@@ -1,368 +1,79 @@
-# Content Module
+# Content Script
 
-The content script runs in page context. It injects the React sidebar, coordinates extraction, and routes messages to/from the background.
+Code under `src/content/` runs inside each tab.  It injects the React sidebar,
+mediates background ↔ page messaging, and owns the extraction pipeline that
+turns the active document into structured text for the chat surface.
 
-## Overview
-
-- Sidebar injection and lifecycle management
-- Robust page content extraction
-- Typed message routing with timeouts
-- DOM patching for asset loading
-
-## Structure
+## Layout
 
 ```
 content/
-├─ index.ts                   # Entry & initialization
+├─ index.ts                  # Bootstrap: patch document, mount sidebar, wire messages
 ├─ core/
-│  ├─ documentPatcher.ts     # Resolve asset URLs safely
-│  ├─ messageHandler.ts      # Route incoming messages
-│  └─ sidebarController.ts   # Mount/unmount Shadow‑DOM UI
+│  ├─ documentPatcher.ts     # Rewrites asset URLs so imported CSS/fonts load inside the tab
+│  ├─ messageHandler.ts      # Typed message dispatcher (TOGGLE_SIDEBAR, EXTRACT_TAB_CONTENT, …)
+│  └─ sidebarController.ts   # Mount/unmount React app inside a Shadow DOM root
 ├─ extraction/
-│  ├─ orchestrator.ts        # Selects mode, enforces timeout
-│  ├─ extractors/
-│  │  ├─ readability.ts      # Default: Mozilla Readability → Markdown
-│  │  ├─ raw.ts              # Preserve HTML structure (good for tables)
-│  │  └─ defuddle.ts         # Defuddle‑based extraction
-│  └─ analyzers/
-│     ├─ contentAnalyzer.ts  # Code/table detection, excerpt
-│     └─ metadataExtractor.ts# Title/OG/Twitter meta
+│  ├─ orchestrator.ts        # Chooses an extraction mode and enforces timeouts
+│  ├─ extractors/            # Readability, Raw HTML, and Defuddle implementations
+│  ├─ analyzers/             # Metadata + discussion detectors appended to results
+│  └─ sites/                 # Optional site-specific plugins loaded at runtime
 └─ utils/
-   ├─ domUtils.ts            # DOM helpers
-   └─ tabUtils.ts            # Tab helpers
+   ├─ domUtils.ts            # DOM helpers that avoid clobbering the host page
+   └─ tabUtils.ts            # Glue for tab metadata + message payloads
 ```
 
-## Architecture Overview
-
-```
-Web Page Context
-    ↓
-Content Script (content/)
-    ├─ Document Patcher (asset URLs)
-    ├─ Message Handler (routing)
-    ├─ Sidebar Controller (UI)
-    └─ Extraction Pipeline (content)
-        ├─ Orchestrator
-        ├─ Extractors
-        ├─ Converters
-        └─ Analyzers
-```
-
-## Core Components
-
-### Entry Point (`index.ts`)
-
-Initialization sequence:
-
-1. Apply document patches for asset URL resolution
-2. Initialize sidebar controller
-3. Set up message handler
-4. Notify background script of readiness
-
-### Core Modules (`core/`)
-
-#### Document Patcher
-
-Patches DOM APIs to ensure dynamic content uses proper extension URLs:
-
-- Intercepts `document.querySelector` for link elements
-- Patches `document.createElement` for scripts/links
-- Converts relative paths to extension URLs
-
-#### Message Handler
-
-Routes messages from the background script:
-
-- `TOGGLE_SIDEBAR` - Show/hide sidebar
-- `CLOSE_SIDEBAR` - Force close sidebar
-- `EXTRACT_CONTENT` - Extract page content
-- `PING` - Health check
-
-#### Sidebar Controller
-
-Manages sidebar lifecycle:
-
-- Lazy loads React sidebar app
-- Tracks open/closed state
-- Handles mount/unmount operations
-- Dispatches custom DOM events
-
-### Content Extraction (`extraction/`)
-
-#### Orchestrator
-
-Selects a mode, validates options, enforces a timeout, and returns structured content. Default mode is Readability; callers may request Raw, Defuddle, or Selection.
-
-#### Extractors
-
-**Readability** (`readability.ts`)
-
-- Reader‑friendly extraction via Mozilla Readability
-- Converts HTML → Markdown (via `@core/extraction/markdownConverter`)
-- Detects tables and generates excerpts
-
-**Raw Extractor** (`raw.ts`)
-
-- Preserves HTML structure
-- Table-aware extraction
-- Token optimization (40-70% reduction)
-- Best for structured data sites
-
-**Defuddle** (`defuddle.ts`)
-
-- Alternative extraction using the `defuddle` library
-- Useful fallback on some article pages
-
-#### Converters
-
-**Markdown Converter** (`markdownConverter.ts`)
-
-- HTML to GitHub Flavored Markdown
-- Preserves code blocks with languages
-- Handles tables, lists, formatting
-- Optional link preservation
-
-#### Analyzers
-
-**Content Analyzer** (`contentAnalyzer.ts`)
-
-- Detects code blocks and tables
-- Counts words
-- Generates excerpts
-- Identifies content features
-
-**Metadata Extractor** (`metadataExtractor.ts`)
-
-- Extracts title, author, date
-- Parses Open Graph tags
-- Handles Twitter Card meta
-- Supports various metadata formats
-
-### Utilities (`utils/`)
-
-- DOM helpers for safe operations in page context
-- Tab helpers for metadata and messaging
-
-## Extraction Pipeline
-
-### Flow Diagram
-
-```
-Page Content
-    ↓
-Orchestrator
-    ├─ Validate Options
-    ├─ Select Extractor
-    │   ├─ Defuddle (articles)
-    │   └─ Raw (tables/data)
-    ├─ Clean HTML
-    ├─ Convert Format
-    │   └─ Markdown
-    ├─ Analyze Content
-    │   ├─ Word Count
-    │   ├─ Code Detection
-    │   └─ Table Detection
-    └─ Apply Limits
-        └─ Return Result
-```
-
-### Extraction Options
-
-```ts
-interface ExtractionOptions {
-  includeLinks?: boolean; // Default: false
-  maxLength?: number; // Default: 200_000
-  timeout?: number; // Default: 2000ms
-}
-// Mode is selected separately via ExtractionMode (readability | raw | defuddle | selection)
-```
-
-## API Usage
-
-### Basic Extraction
-
-```typescript
-import { extractContent } from '@content/extraction';
-
-// Default extraction (Defuddle mode)
-const content = await extractContent();
-
-// With options
-const content = await extractContent({
-  timeout: 5000,
-  includeLinks: false,
-  maxLength: 100000,
-});
-```
-
-### Raw Mode Extraction
-
-```ts
-import { ExtractionMode } from '@types/extraction';
-import { extractContent } from '@content/extraction/orchestrator';
-
-// Table‑heavy pages: returns HTML + text (no Markdown conversion)
-const content = await extractContent({ includeLinks: true }, ExtractionMode.RAW);
-```
-
-### HTML to Markdown
-
-The Markdown converter lives in `@core/extraction` and is used by the orchestrator
-for non-RAW modes. You can import it directly if needed:
-
-```typescript
-import { htmlToMarkdown } from '@core/extraction/markdownConverter';
-
-const markdown = await htmlToMarkdown(htmlString, { includeLinks: true });
-```
-
-### Content Analysis
-
-The analyzer utilities live under `@core/extraction/analyzers` and are used by extractors to populate metadata (tables, excerpts, etc.).
-
-## Message Communication
-
-### Receiving Messages
-
-Content script primarily responds to `EXTRACT_TAB_CONTENT` via the background message orchestrated in `extension/background/messageHandler.ts`.
-
-### Sending Messages
-
-```typescript
-// To background script
-chrome.runtime.sendMessage({
-  type: 'CONTENT_READY',
-  tabId: getCurrentTabId(),
-});
-```
-
-## Error Handling
-
-### Error Types
-
-- `EXTRACTION_TIMEOUT` - Operation exceeded time limit
-- `EXTRACTION_NETWORK_ERROR` - Network-related failure
-- `EXTRACTION_DOM_ERROR` - DOM access issues
-- `EXTRACTION_MEMORY_ERROR` - Memory constraints
-- `EXTRACTION_PARSING_ERROR` - Content parsing failed
-
-### Error Recovery
-
-- Timeout protection on all operations
-- Graceful degradation to basic extraction
-- Fallback strategies for each extractor
-- Safe DOM access with edge case handling
-
-## Security
-
-- Readability sanitizer + Markdown conversion minimize unsafe HTML in default mode
-- No script execution; avoid direct `innerHTML` without sanitization
-- Operates in an isolated content‑script world
-
-### Best Practices
-
-1. Never execute extracted scripts
-2. Sanitize all HTML content
-3. Validate URLs before processing
-4. Use timeout protection
-5. Handle memory constraints
-
-## Performance
-
-Optimization highlights:
-
-- Dynamic import caching per extractor
-- Timeout enforcement in orchestrator
-- Raw mode avoids Markdown conversion for speed and token savings
-
-## Testing
-
-### Test Coverage
-
-```bash
-# Run all content tests
-npm test -- src/content
-
-# Specific test suites
-npm test -- src/content/extraction
-npm test -- src/content/core
-npm test -- src/content/utils
-```
-
-### Test Types
-
-- Unit tests for utilities
-- Integration tests for pipeline
-- E2E tests for sidebar interaction
-- Performance benchmarks
-
-## Debugging
-
-### Enable Debug Logging
-
-```typescript
-// In any module
-const DEBUG = true; // Enable verbose logging
-```
-
-### Chrome DevTools
-
-1. Open target web page
-2. Open DevTools Console
-3. Filter by "ContentExtractor" or module name
-4. Check extraction timing and errors
-
-### Common Issues
-
-#### Content Not Extracting
-
-- Check if page has restricted permissions
-- Verify extraction timeout settings
-- Check for DOM mutation after load
-
-#### Sidebar Not Appearing
-
-- Verify content script injection
-- Check message passing
-- Confirm sidebar controller initialization
-
-## Extraction Modes Comparison
-
-| Feature         | Defuddle Mode     | Raw Mode        |
-| --------------- | ----------------- | --------------- |
-| Best For        | Articles, blogs   | Tables, data    |
-| Removes         | Ads, navigation   | Minimal removal |
-| Preserves       | Article content   | Full structure  |
-| Token Reduction | 60-80%            | 40-70%          |
-| Speed           | Fast              | Very fast       |
-| Accuracy        | High for articles | High for data   |
-
-## Dependencies
-
-- **defuddle** - Intelligent content extraction
-- **dompurify** - HTML sanitization (via Defuddle)
-- **Chrome APIs** - Extension communication
-- Markdown conversion is provided by `@core/extraction/markdownConverter` (Turndown + GFM)
-
-## Future Enhancements
-
-- Domain heuristics for extractor selection
-- Incremental extraction for long pages
-- PDF/Doc export
-
-## Contributing
-
-### Development Guidelines
-
-1. **Module Independence** - Self-contained modules
-2. **Error Handling** - Graceful edge case handling
-3. **Type Safety** - Full TypeScript coverage
-4. **Documentation** - Inline documentation for complex logic
-5. **Performance** - Consider memory and CPU impact
-
-### Code Standards
-
-- TypeScript strict mode
-- ESLint + Prettier formatting
-- 80% minimum test coverage
-- Comprehensive error handling
+## Extraction pipeline
+
+* `orchestrator.ts` normalises `ExtractionOptions`, applies domain-specific
+  defaults saved in Chrome storage, and races the chosen extractor against a
+  timeout.  Supported modes (`ExtractionMode`) are **readability** (default),
+  **raw**, **defuddle**, and a **selection** fallback that emits the current user
+  selection when present.
+* Extractors live in `extraction/extractors/` and are lazy-loaded to keep the
+  injected bundle small.  Readability converts DOM → Markdown via
+  `@core/extraction/markdownConverter`, Raw returns a lightly cleaned HTML/Markdown
+  pair, and Defuddle delegates to the third-party parser.
+* After extraction the orchestrator runs the analyzers: `metadataExtractor`
+  collects title/author/description, while `discussionExtractor` identifies forum
+  threads and highlights useful snippets.
+* `extraction/sites/` exposes opt-in plugins (`*.plugin.ts`) that can short-circuit
+  the default modes for known domains.  The loader also picks up local overrides
+  from the gitignored `/site-plugins/` directory so developers can test private
+  rules without committing them.
+
+The resolved `ExtractedContent` is cached by the background service worker but
+always originates from this pipeline.
+
+## Messaging contract
+
+`core/messageHandler.ts` registers handlers for a small set of typed messages
+(see `@/types/messages.ts`):
+
+* `TOGGLE_SIDEBAR` / `CLOSE_SIDEBAR` drive sidebar visibility.
+* `PING` responds with `PONG` so the background can detect whether the content
+  script is available and decide if it should inject again.
+* `EXTRACT_TAB_CONTENT` runs the orchestrator and returns
+  `CONTENT_EXTRACTED` with the resulting payload (or `ERROR` if extraction
+  fails).  Timeouts and errors propagate back to the background worker so the UI
+  can surface them.
+
+Message handlers use the shared `createMessage` helper to guarantee consistent
+shape and timestamps across extension components.
+
+## Working with the sidebar controller
+
+`sidebarController.ts` ensures the UI is mounted in a Shadow DOM container
+attached to the document body.  It tracks whether the root exists, provides
+helpers for focus/cleanup, and exposes `showSidebar`/`hideSidebar` so the
+background can toggle the UI without re-injecting the bundle.
+
+## Extending the module
+
+* Add a new extractor under `extraction/extractors/` and update the switch in
+  `orchestrator.ts` when a new mode is required.
+* Register additional message types in `core/messageHandler.ts` and export their
+  payload definitions from `@/types/messages`.
+* Keep DOM helpers pure and side-effect free—anything that mutates the page
+  should be centralised in `documentPatcher.ts` or an extractor to avoid
+  surprising host pages.

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,120 +1,78 @@
-# Core Module
+# Core module
 
-Central business logic for the AI Browser Sidebar: provider adapters, engine wrappers, and extraction helpers.
-
-## Overview
-
-The core module separates provider protocol glue from runtime orchestration:
-
-- `ai/` contains stateless, provider‑specific helpers (build requests, parse streams, map errors).
-- `engine/` contains stateful provider classes that implement a common interface, hold config, and wire transports. Engines call into `ai/` to talk to each vendor.
-- `extraction/` contains HTML → Markdown conversion and lightweight analyzers used by content extraction.
-
-This split lets us keep protocol details testable and isolated while giving the app a uniform, class‑based provider surface.
+Provider integrations, engine orchestration, and shared extraction utilities
+live under `src/core/`.  The goal is to keep vendor-specific glue pure and
+stateless while the rest of the extension talks to consistent interfaces.
 
 ## Structure
 
 ```
 core/
-├── ai/                      # Provider protocol helpers (stateless)
-│   ├── openai/              # Request builders, stream processors, error mappers
-│   ├── gemini/
-│   ├── openrouter/
-│   └── openai-compat/
-├── engine/                  # Stateful providers + orchestration
-│   ├── BaseEngine.ts        # Shared lifecycle, validation, streaming wrapper
-│   ├── EngineFactory.ts     # Creates providers, injects transport
-│   ├── EngineRegistry.ts    # Register/set active provider
-│   ├── openai/              # OpenAIProvider.ts (uses ai/openai/*)
-│   ├── gemini/              # GeminiProvider.ts (uses ai/gemini/*)
-│   ├── openrouter/          # OpenRouterProvider.ts (uses ai/openrouter/*)
-│   └── openai-compat/       # OpenAICompatibleProvider.ts
-└── extraction/              # HTML→Markdown + analyzers
-    ├── analyzers/
-    ├── markdownConverter.ts
-    └── text.ts
+├─ ai/                # Request builders, stream parsers, and error mappers per provider
+├─ engine/            # Stateful engine classes built on top of the AI helpers
+├─ extraction/        # Markdown conversion + analyzers reused by content + sidebar
+├─ services/          # Provider-agnostic helpers (file uploads, model switching, tab sync)
+└─ utils/             # Small shared helpers (token accounting, retry helpers, …)
 ```
 
-## ai vs engine
+### `ai/`
 
-- ai (stateless)
-  - Build HTTP payloads for each vendor (e.g., `ai/openai/requestBuilder.ts`).
-  - Parse vendor streaming events into a normalized delta (`ai/*/streamProcessor.ts`).
-  - Map vendor errors to `ProviderError` (`ai/*/errorHandler.ts`).
-  - No transport, no app state; pure, easily unit‑tested logic.
+Each provider (OpenAI, Gemini, OpenRouter, OpenAI-compatible) gets its own
+subfolder.  Modules here build HTTP payloads, parse streaming deltas into the
+normalised `StreamChunk` shape, and translate vendor-specific errors into
+`ProviderError` objects.  Everything is pure functions so unit tests can load
+fixtures without mocking transports.
 
-- engine (stateful)
-  - Provider classes extend `BaseEngine` (config, capability flags, validation, rate limiting hooks).
-  - Inject a `Transport` (default: `DirectFetchTransport`) and call `ai/` helpers to perform requests.
-  - Yield normalized `StreamChunk` objects consumed by the UI.
-  - Factory/Registry manage creation and selection: `EngineFactory.ts`, `EngineRegistry.ts`.
+### `engine/`
 
-Data flow
+Engines wrap the `ai/` helpers with lifecycle state:
 
-```
-ProviderChatMessage[]
-  → engine/<Provider>.streamChat(...)
-    → ai/<provider>/requestBuilder → Transport.stream(fetch ...)
-      → ai/<provider>/streamProcessor → StreamChunk → UI
-```
+* `BaseEngine` provides transport wiring, capability flags, and cancellation
+  hooks.
+* `EngineFactory` instantiates providers on demand (injecting
+  `DirectFetchTransport` by default) and exposes convenience creators such as
+  `createOpenAIProvider()`.
+* `EngineRegistry` tracks registered providers and the active engine.  It is the
+  backing store for `EngineManagerService`.
 
-## Usage
+Provider-specific folders (e.g. `engine/openai/`) extend `BaseEngine` and expose
+`streamChat()` implementations that yield normalised chunks consumed by the UI
+and services.
 
-Create and register a provider
+### `extraction/`
 
-```ts
-import { EngineFactory } from '@core/engine/EngineFactory';
-import { EngineRegistry } from '@core/engine/EngineRegistry';
-import type { ProviderChatMessage } from '@/types/providers';
+Shared helpers used both by the content script and by any server-side tests:
 
-const factory = new EngineFactory();
-const registry = new EngineRegistry();
+* `markdownConverter.ts` turns DOM fragments into GitHub-flavoured Markdown with
+  KaTeX/code block support.
+* `analyzers/` (and `text.ts`) compute word counts, table/code detection, and
+  summarised excerpts that feed the UI badges.
 
-// Example: OpenAI
-await factory.createAndRegister(
-  { type: 'openai', config: { apiKey: 'sk-...', model: 'gpt-5-nano' } },
-  registry
-);
+### `services/`
 
-registry.setActiveProvider('openai');
-const provider = registry.getActiveProvider();
+Lightweight utilities that sit underneath the higher-level `src/services/`
+facades:
 
-const messages: ProviderChatMessage[] = [
-  { id: 'u1', role: 'user', content: 'Hello!', timestamp: new Date() },
-];
+* `fileUpload.ts` normalises multi-part uploads before they reach a provider.
+* `messageEditing.ts` prepares edit/regenerate payloads.
+* `modelSwitching.ts` centralises logic for validating requested model changes.
+* `tabContent.ts` stitches extracted tab payloads together before they are sent
+  to providers that support multi-tab context.
 
-for await (const chunk of provider!.streamChat(messages, { systemPrompt: 'Be concise.' })) {
-  // chunk.choices[0].delta.content / delta.thinking, etc.
-}
-```
+### `utils/`
 
-Direct creation helpers also exist in the factory, e.g. `createOpenAIProvider`, `createGeminiProvider`.
+Contains small shared helpers (e.g. retry utilities) that do not warrant their
+own package yet.  Keep them pure so they can be reused in both background and UI
+contexts.
 
-## When to add code
+## Working with providers
 
-- Add to `core/ai/<provider>/` when:
-  - The vendor’s payload shape, SSE event format, or error mapping changes.
-  - You need request/response utilities that are provider‑specific and stateless.
+When adding a new model/vendor:
 
-- Add to `core/engine/<provider>/` when:
-  - Introducing a new provider class or wiring config/transport/capabilities.
-  - You need to expose a consistent `streamChat` that uses `ai/` helpers.
-
-- Add/adjust models in `src/config/models.ts` when introducing model IDs, defaults, or capability flags.
-
-## Transports
-
-- `DirectFetchTransport` (default) performs fetch with streaming.
-- `BackgroundProxyTransport` can proxy via the extension background if needed.
-  Engines receive a transport (factory injects `DirectFetchTransport` by default).
-
-## Testing
-
-- Unit tests for protocol helpers live under `tests/unit/core/ai/**` (request builders, stream processors, mappers).
-- Run with `npm test` or `npm run test:watch`.
-
-## Notes and tips
-
-- OpenAI Responses API: we send `tools: [{ type: 'web_search' }]` by default and stream reasoning/thinking when supported. Search metadata is surfaced via chunk metadata (see `ai/openai/responseParser.ts`).
-- Keep `ai/` functions pure and side‑effect free; engines own state and validation.
-- Use path aliases (`@core`, `@config`, `@transport`, etc.).
+1. Implement the request builder + stream parser under `ai/<provider>/`.
+2. Create an engine in `engine/<provider>/` that extends `BaseEngine` and wires
+   transports/capabilities.
+3. Register the model in `config/models.ts` and expose any required defaults in
+   `EngineFactory`.
+4. Surface provider availability through `EngineManagerService` so the UI can
+   toggle it at runtime.

--- a/src/data/store/README.md
+++ b/src/data/store/README.md
@@ -1,48 +1,63 @@
-# Zustand Stores
+# Zustand stores
 
-Chat/session state lives in a set of small, focused stores. Only the session store holds data; the others delegate to the active session.
+Chat/session state is handled by a collection of focused Zustand stores.  The
+structure mirrors the sidebar UI: a master session map plus stores that expose
+a per-session view for messages, tab content, and UI flags.  Persistent settings
+are handled separately so transient chat state never hits disk.
 
-## Stores
+## Directory
 
 ```
-useSessionStore  # sessions map + activeSessionKey + create/switch/clear
-useMessageStore  # add/update/delete messages in the active session
-useTabStore      # manage extracted tab content for the active session
-useUIStore       # loading/error/activeMessageId for the active session
-useSettingsStore # persistent user settings and API key refs
+store/
+├─ chat.ts          # Barrel that re-exports all chat-related stores + helpers
+├─ index.ts         # Generic app store factory used by tests
+├─ settings.ts      # Persistent settings store with Chrome storage sync
+├─ stores/          # Concrete Zustand stores (session, message, tab, ui)
+├─ types/           # Shared TypeScript interfaces for the stores
+└─ utils/chatHelpers.ts # Session-key helpers + initialisers
 ```
 
-## Session keying
+### Session hierarchy
 
-`createSessionKey(tabId, url)` → `tab_{id}:{normalizedUrl}` (query kept, hash dropped). See `@shared/utils/urlNormalizer`.
+```
+useSessionStore ─┬─ useMessageStore  (CRUD on active session messages)
+                 ├─ useTabStore      (per-session extracted tab cache)
+                 └─ useUIStore       (streaming flags, active message ids, errors)
+```
+
+* `useSessionStore` tracks the `sessions` map and `activeSessionKey`.  The
+  helper `switchSession(tabId, url)` derives deterministic keys via
+  `@shared/utils/urlNormalizer`.
+* The other stores delegate to whatever session key `useSessionStore` marks as
+  active, keeping their own selectors shallow so React components can subscribe
+  efficiently.
+* `useSettingsStore` in `settings.ts` persists the settings schema to Chrome
+  storage (`sync` with fallback to `local`).  It also computes the
+  `availableModels` list by combining `config/DEFAULT_MODELS` with the API-key
+  metadata stored in `data/storage/keys` and any OpenAI-compatible providers
+  saved through `data/storage/keys/compat`.
+
+### Utilities
+
+`utils/chatHelpers.ts` exposes helpers for building session keys, seeding
+sessions from extracted tab data, and wiping state when tabs close.  Prefer
+those helpers to keep behaviour consistent between tests, the sidebar, and the
+service worker.
 
 ## Usage
 
 ```ts
 import { useSessionStore, useMessageStore, useTabStore, useUIStore } from '@data/store/chat';
 
-// Switch to the session for the current tab+URL
-const sessionStore = useSessionStore.getState();
-sessionStore.switchSession(tabId, url);
+const { switchSession } = useSessionStore.getState();
+switchSession(tabId, url);
 
-// Add a user message
-const messageStore = useMessageStore.getState();
-const msg = messageStore.addMessage({ role: 'user', content: 'Hello!' });
+const { addMessage } = useMessageStore.getState();
+addMessage({ role: 'user', content: 'Hello world' });
 
-// Update UI while streaming
-const uiStore = useUIStore.getState();
-uiStore.setLoading(true);
-
-// Save extracted content for the active session
-const tabStore = useTabStore.getState();
-tabStore.addLoadedTab(tabId, extractedContent);
+const { setLoading } = useUIStore.getState();
+setLoading(true);
 ```
 
-## Settings
-
-`useSettingsStore` persists to Chrome storage and gates available models by saved API keys and OpenAI‑Compat providers. See `data/store/settings.ts` for details.
-
-## Notes
-
-- Stores are plain Zustand without persistence (except settings). Keep operations minimal and synchronous where possible.
-- Prefer selectors when subscribing in React components to avoid unnecessary re‑renders.
+Always mutate through the exported actions—directly touching the underlying
+state objects may bypass derived-state updates.

--- a/src/extension/README.md
+++ b/src/extension/README.md
@@ -1,442 +1,66 @@
-# Extension Module
+# Extension (MV3 service worker)
 
-The extension module provides the core Chrome Extension infrastructure including the service worker, message passing system, and tab state management.
+`src/extension/` hosts the Manifest V3 background script and its messaging
+infrastructure.  The service worker keeps the sidebar injected, coordinates tab
+extraction, and proxies network calls that cannot run from the content script.
 
-## Directory Structure
+## Directory
 
 ```
 extension/
-├─ background/              # Service worker components
-│  ├─ index.ts             # Entry point
-│  ├─ keepAlive.ts         # Keep‑alive mechanism
-│  ├─ messageHandler.ts    # Typed message registry/dispatch
-│  ├─ sidebarManager.ts    # Per‑tab sidebar lifecycle
-│  ├─ tabManager.ts        # Tab lifecycle + extraction orchestration
-│  ├─ cache/TabContentCache.ts # Session‑storage TTL cache (5 minutes)
-│  └─ queue/ExtractionQueue.ts # Concurrency‑limited extraction queue
-└─ messaging/               # Message helpers
-   ├─ index.ts
-   ├─ errors.ts
-   └─ responses.ts
+├─ background/
+│  ├─ index.ts          # Entry point: registers handlers and keep-alive
+│  ├─ keepAlive.ts      # Periodic ping to avoid premature worker suspension
+│  ├─ messageHandler.ts # Registry of typed message handlers
+│  ├─ proxyHandler.ts   # Fetch/stream proxy for CORS-restricted endpoints
+│  ├─ sidebarManager.ts # Tracks which tabs have the sidebar open
+│  ├─ tabManager.ts     # Tab lookup + extraction + content-script injection
+│  ├─ cache/            # TabContentCache (chrome.storage.session with TTLs)
+│  └─ queue/            # FIFO ExtractionQueue with concurrency limits
+└─ messaging/
+   ├─ index.ts          # Helpers for sending typed responses
+   ├─ errors.ts         # Standardised error codes for messaging failures
+   └─ responses.ts      # Utility builders for success/error payloads
 ```
 
-## Architecture Overview
-
-```
-User Click → Extension Icon
-    ↓
-Background Service Worker
-    ├─ Tab State Management
-    ├─ Message Routing
-    ├─ Keep-Alive System
-    └─ Content Caching
-        ↓
-Content Script (content)
-    ↓
-Sidebar UI (React)
-```
-
-## Core Components
-
-### Background Service Worker
-
-#### `index.ts` - Entry Point
-
-The main service worker that:
-
-- Handles extension installation and updates
-- Listens for icon clicks to toggle sidebar
-- Routes messages between components
-- Manages service worker lifecycle
-
-#### `keepAlive.ts` - Persistence
-
-Prevents service worker termination during:
-
-- Long-running operations
-- API key validation
-- Content extraction
-- WebSocket connections
-
-**Implementation:**
-
-- Creates persistent Chrome runtime port
-- Sends periodic pings (25-second intervals)
-- Graceful disconnection when complete
-
-#### `messageHandler.ts` - Message Router
-
-Central hub for all extension communication:
-
-**Selected Message Types:**
-
-- `TOGGLE_SIDEBAR`, `CLOSE_SIDEBAR`
-- `GET_TAB_ID`, `GET_TAB_INFO`, `GET_ALL_TABS`
-- `EXTRACT_TAB_CONTENT` (response: `CONTENT_EXTRACTED`)
-- `CLEANUP_TAB_CACHE`
-- `PROXY_REQUEST`
-- `PING`/`PONG`, `ERROR`
-
-**Features:**
-
-- Type-safe message contracts
-- Async message processing
-- Centralized error handling
-- Structured responses
-
-#### `sidebarManager.ts` - Sidebar State
-
-Manages per-tab sidebar state:
-
-- Tracks open/closed status
-- Handles content script injection
-- Persists state across sessions
-- Cleans up on tab close/navigation
-
-#### `tabManager.ts` - Tab Lifecycle
-
-Handles tab-specific operations:
-
-- Tab creation and updates
-- Navigation detection
-- Tab removal cleanup
-- State synchronization
-
-### Content Caching (`cache/`)
-
-#### `TabContentCache.ts`
-
-Stores extracted content in `chrome.storage.session` with a 5‑minute TTL. Expired entries are cleared on access and via periodic cleanup. Session storage limits apply.
-
-### Extraction Queue (`queue/`)
-
-#### `ExtractionQueue.ts`
-
-Manages content extraction requests:
-
-**Features:**
-
-- FIFO queue processing
-- Concurrent extraction limits
-- Retry logic with exponential backoff
-- Priority queue support
-- Error recovery
-
-**Queue States:**
-
-- `pending` - Waiting to process
-- `processing` - Currently extracting
-- `completed` - Successfully extracted
-- `failed` - Extraction failed
-
-## Message Flow
-
-### Sidebar Toggle Flow
-
-```
-1. User clicks extension icon
-2. Background receives chrome.action.onClicked
-3. Background checks tab state
-4. Background sends TOGGLE_SIDEBAR to content script
-5. Content script dispatches DOM event
-6. Sidebar React app mounts/unmounts
-7. State saved to Chrome storage
-```
-
-### Content Extraction Flow
-
-```
-1. Sidebar requests content extraction
-2. Message sent to background
-3. Background checks cache
-4. If not cached:
-   - Adds to extraction queue
-   - Content script extracts content
-   - Result cached with TTL
-5. Content returned to sidebar
-```
-
-## State Management
-
-### Tab State Interface
-
-```typescript
-interface TabState {
-  id: number;
-  url: string;
-  title: string;
-  sidebar: {
-    isOpen: boolean;
-    isInjected: boolean;
-    position?: { x: number; y: number };
-    size?: { width: number; height: number };
-  };
-  extraction?: {
-    lastExtracted: number;
-    contentHash: string;
-  };
-}
-```
-
-### Storage Strategy
-
-- **Primary**: `chrome.storage.local` for persistence
-- **Fallback**: `chrome.storage.session` for temporary data
-- **Debouncing**: 500ms delay to prevent excessive writes
-- **Migration**: Automatic version migration on updates
-
-## API Reference
-
-### Background API
-
-#### Sidebar Operations
-
-```typescript
-toggleSidebar(tabId: number): Promise<void>
-openSidebar(tabId: number): Promise<void>
-closeSidebar(tabId: number): Promise<void>
-isSidebarOpen(tabId: number): Promise<boolean>
-```
-
-#### State Management
-
-```typescript
-saveTabState(tabId: number, state: Partial<TabState>): Promise<void>
-getTabState(tabId: number): Promise<TabState | null>
-clearTabState(tabId: number): Promise<void>
-getAllTabStates(): Promise<Map<number, TabState>>
-```
-
-#### Message Handling
-
-```typescript
-sendMessage(tabId: number, message: Message): Promise<any>
-broadcast(message: Message): Promise<void>
-onMessage(handler: MessageHandler): void
-```
-
-### Content Script Communication
-
-#### Sending Messages
-
-```typescript
-// Content → Background
-chrome.runtime.sendMessage(message);
-
-// Background → Content
-chrome.tabs.sendMessage(tabId, message);
-```
-
-#### Receiving Messages
-
-```typescript
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  // Handle message
-  sendResponse({ success: true, data: result });
-  return true; // Keep channel open for async response
-});
-```
-
-## Security
-
-### Permissions
-
-**Required:**
-
-- `storage` - Save user settings
-- `activeTab` - Access current tab
-
-**Optional:**
-
-- `clipboardWrite` - Copy functionality
-- `downloads` - Export conversations
-- `notifications` - User notifications
-
-### Content Security Policy
-
-```json
-{
-  "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'none'"
-  }
-}
-```
-
-### Best Practices
-
-1. Validate all message sources
-2. Sanitize external inputs
-3. Use minimal permissions
-4. No eval() or Function()
-5. HTTPS-only connections
-6. Validate message structure
-
-## Performance
-
-### Optimization Strategies
-
-#### Lazy Loading
-
-- Dynamic imports for heavy modules
-- On-demand content script injection
-- Deferred initialization
-
-#### Memory Management
-
-- LRU cache with size limits
-- Automatic garbage collection
-- Memory usage monitoring
-- Resource cleanup on tab close
-
-#### Message Optimization
-
-- Batch message sending
-- Debounced state updates
-- Compressed payloads for large data
-
-### Performance Metrics
-
-- Service worker startup: <50ms
-- Message round-trip: <10ms
-- State save: <5ms (debounced)
-- Cache lookup: <1ms
-
-## Debugging
-
-### Chrome DevTools
-
-1. Navigate to `chrome://extensions`
-2. Enable Developer mode
-3. Click "Inspect views: service worker"
-4. Use Console, Network, Sources tabs
-
-### Debug Commands
-
-```javascript
-// Check all tabs
-chrome.tabs.query({}, tabs => console.log(tabs));
-
-// View storage
-chrome.storage.local.get(null, data => console.log(data));
-
-// Monitor messages
-chrome.runtime.onMessage.addListener((msg, sender) => {
-  console.log('Message:', msg, 'From:', sender);
-});
-
-// Check permissions
-chrome.permissions.getAll(perms => console.log(perms));
-```
-
-### Common Issues
-
-#### Service Worker Stops
-
-**Solution:** Implement keep-alive with alarms
-
-```typescript
-chrome.alarms.create('keepAlive', { periodInMinutes: 1 });
-chrome.alarms.onAlarm.addListener(() => {
-  // Lightweight operation to keep worker alive
-});
-```
-
-#### Content Script Not Injecting
-
-**Solution:** Check URL restrictions and permissions
-
-```typescript
-const isRestrictedUrl = (url: string) => {
-  return url.startsWith('chrome://') || url.startsWith('edge://') || url.startsWith('about:');
-};
-```
-
-#### Message Not Received
-
-**Solution:** Ensure async response handling
-
-```typescript
-// Always return true for async responses
-return true;
-```
-
-## Testing
-
-### Unit Tests
-
-```typescript
-// Test message handler
-describe('MessageHandler', () => {
-  it('routes messages correctly', () => {
-    const handler = new MessageHandler();
-    const spy = jest.fn();
-    handler.on('TOGGLE_SIDEBAR', spy);
-    handler.handle({ type: 'TOGGLE_SIDEBAR' });
-    expect(spy).toHaveBeenCalled();
-  });
-});
-```
-
-### Integration Tests
-
-```typescript
-// Test complete flow
-it('toggles sidebar on icon click', async () => {
-  await chrome.action.onClicked.dispatch({ id: 1 });
-  const state = await getTabState(1);
-  expect(state.sidebar.isOpen).toBe(true);
-});
-```
-
-## Browser Compatibility
-
-Chromium‑based browsers (Chrome, Edge, Arc, Brave, Opera). Some system pages are restricted by design.
-
-## Future Enhancements
-
-### Planned Features
-
-1. WebSocket support for real-time updates
-2. Offline mode with sync capabilities
-3. Cross-device state synchronization
-4. Custom keyboard shortcuts
-5. Performance monitoring dashboard
-6. Extension API for third-party integrations
-
-### Experimental Features
-
-Enable via feature flags:
-
-- Advanced caching strategies
-- Predictive content pre-extraction
-- Machine learning for tab prioritization
-
-## Contributing
-
-### Development Setup
-
-```bash
-# Clone and install
-git clone <repository>
-npm install
-
-# Development build with watch
-npm run watch
-
-# Run tests
-npm test
-
-# Production build
-npm run build
-```
-
-### Code Standards
-
-- TypeScript strict mode
-- ESLint + Prettier
-- 80% minimum test coverage
-- Comprehensive error handling
-
-## License
-
-MIT License - Part of the AI Browser Sidebar Extension project
+## Background workflow
+
+1. **Initialisation** (`background/index.ts`)
+   * Creates a `MessageHandlerRegistry` populated by `createDefaultMessageHandler()`.
+   * Registers listeners for installation, startup, runtime messages, long-lived
+     ports (proxy streaming), and the extension action click.
+   * Bootstraps the keep-alive loop to keep the worker alive while the sidebar is
+     open or extraction is running.
+
+2. **Sidebar lifecycle** (`sidebarManager.ts`)
+   * Maintains a per-tab map of open/closed state and cleans up when tabs close
+     or navigate.
+   * Responds to `TOGGLE_SIDEBAR` / `CLOSE_SIDEBAR` by injecting the content
+     script if necessary and relaying the toggle message back to the tab.
+
+3. **Extraction** (`tabManager.ts`)
+   * Provides `getAllTabs()`, `getTab()`, and `extractTabContent()` helpers.
+   * Uses `ExtractionQueue` to cap concurrent extractions and `TabContentCache`
+     to memoise results in `chrome.storage.session`.
+   * Ensures the content script is present (`ensureContentScript`) and retries
+     injection by reading the manifest’s declared content scripts.
+
+4. **Proxying** (`proxyHandler.ts`)
+   * Implements a request/response proxy and a streaming variant (`proxy-stream`
+     port) for endpoints flagged by `@transport/policy.shouldProxy`.
+
+## Adding a new message
+
+1. Define the payload type in `@/types/messages.ts`.
+2. Register a handler inside `createDefaultMessageHandler()` (or directly via the
+   registry in `background/index.ts`).
+3. Use `createMessage()` from `messaging/index.ts` when sending responses so the
+   message structure stays consistent with the rest of the extension.
+
+## Testing hooks
+
+* The cache exposes `getStats()`/`cleanupExpired()` so unit tests can inspect
+  eviction behaviour.
+* `ExtractionQueue` is exported as a class and singleton (`extractionQueue`)
+  making it simple to assert queue state or inject a smaller concurrency limit
+  during tests.

--- a/src/services/extraction/README.md
+++ b/src/services/extraction/README.md
@@ -1,172 +1,62 @@
-# Extraction Service
+# ExtractionService
 
-The Extraction Service provides a high-level API for extracting content from browser tabs with retry logic, error handling, and consistent TabContent formatting.
+A high-level facade for requesting tab extraction from the sidebar or tests.
+The service hides Chrome messaging details, adds retry/backoff logic, and
+normalises errors so UI components can display consistent feedback.
 
-## Features
+## Surface
 
-- **Current Tab Extraction**: Extract content from the currently active tab
-- **Multi-Tab Extraction**: Extract content from multiple tabs concurrently
-- **Retry Logic**: Automatic retry with exponential backoff for failed extractions
-- **Error Handling**: Comprehensive error classification and handling
-- **Background Messaging**: Integrates with the existing background script messaging system
-- **TypeScript Support**: Full type safety with proper interfaces
-
-## Usage
-
-### Basic Usage
-
-```typescript
-import { ExtractionService } from '@/services/extraction';
-
-// Create a service instance (typically from sidebar context)
-const extractionService = new ExtractionService('sidebar');
-
-// Extract current tab content
-try {
-  const tabContent = await extractionService.extractCurrentTab();
-  console.log('Extracted content:', tabContent.extractedContent.content);
-} catch (error) {
-  console.error('Extraction failed:', error.message);
-}
+```ts
+import {
+  ExtractionService,
+  createExtractionService,
+  defaultExtractionService,
+  extractCurrentTab,
+  extractTabs,
+  ExtractionError,
+  ExtractionErrorType,
+} from '@services/extraction';
 ```
 
-### Convenience Functions
+* `ExtractionService` instances require a `MessageSource` (usually `'sidebar'`).
+* `extractCurrentTab(options?)` resolves a `TabContent` payload or throws an
+  `ExtractionError` with a typed `ExtractionErrorType`.
+* `extractTabs(tabIds, options?)` runs multiple requests concurrently (honouring
+  the queue inside `TabManager`) and returns a `BatchExtractionResult` with
+  per-tab success flags.
+* `getAllTabs()` proxies `GET_ALL_TABS` to the background worker so the UI can
+  display metadata without directly calling `chrome.tabs`.
 
-```typescript
-import { extractCurrentTab, extractTabs } from '@/services/extraction';
+## Options
 
-// Extract current tab using default service
-const currentTab = await extractCurrentTab({
-  mode: ExtractionMode.DEFUDDLE,
-  timeout: 5000,
-  forceRefresh: true,
-});
+All extraction helpers accept `ServiceExtractionOptions`, which extend the
+shared `ExtractionOptions` with:
 
-// Extract multiple tabs
-const results = await extractTabs([123, 456, 789], {
-  maxRetries: 2,
-  timeout: 3000,
-});
+* `mode?: ExtractionMode` – request Readability/Raw/Defuddle explicitly.
+* `forceRefresh?: boolean` – bypass the background cache.
+* `maxRetries?: number` and `retryDelay?: number` – tune the built-in retry
+  loop (defaults to 2 attempts with a 1s delay).
 
-console.log(`Successfully extracted ${results.successCount}/${results.totalTabs} tabs`);
-```
+## Error handling
 
-### Advanced Configuration
+Errors are surfaced as `ExtractionError` with a `type` enum:
 
-```typescript
-import { ExtractionService, ExtractionMode } from '@/services/extraction';
+* `TIMEOUT`, `TAB_NOT_FOUND`, `CONTENT_SCRIPT_UNAVAILABLE`, `RESTRICTED_URL`,
+  `MESSAGING_ERROR`, or `UNKNOWN`.
 
-const service = new ExtractionService('sidebar');
+Consumers should catch the error and branch on `error.type` to provide user
+feedback.
 
-// Extract with custom options
-const tabContent = await service.extractCurrentTab({
-  mode: ExtractionMode.RAW, // Use raw mode for tables
-  timeout: 10000, // 10 second timeout
-  maxLength: 500000, // 500k character limit
-  forceRefresh: true, // Ignore cache
-  maxRetries: 3, // Retry up to 3 times
-  retryDelay: 2000, // Wait 2s between retries
-});
+## Messaging details
 
-// Batch extraction with error handling
-const batchResults = await service.extractTabs([123, 456, 789]);
+The service uses `createMessage()` from `@/types/messages` and
+`sendMessageToTab()` / `sendMessageAsync()` from `@platform/chrome` to talk to
+`extension/background/tabManager.ts`.  Responses mirror the `CONTENT_EXTRACTED`
+payload used throughout the app.
 
-for (const result of batchResults.results) {
-  if (result.success) {
-    console.log(`Tab ${result.tabId}: ${result.content?.extractedContent.title}`);
-  } else {
-    console.error(`Tab ${result.tabId} failed: ${result.error}`);
-  }
-}
-```
+## Testing
 
-## Error Handling
-
-The service provides comprehensive error classification:
-
-```typescript
-import { ExtractionError, ExtractionErrorType } from '@/services/extraction';
-
-try {
-  const content = await extractCurrentTab();
-} catch (error) {
-  if (error instanceof ExtractionError) {
-    switch (error.type) {
-      case ExtractionErrorType.TIMEOUT:
-        console.log('Extraction timed out');
-        break;
-      case ExtractionErrorType.TAB_NOT_FOUND:
-        console.log('Tab was closed or not found');
-        break;
-      case ExtractionErrorType.RESTRICTED_URL:
-        console.log('Cannot access restricted URL');
-        break;
-      case ExtractionErrorType.CONTENT_SCRIPT_UNAVAILABLE:
-        console.log('Content script not available');
-        break;
-      default:
-        console.log('Unknown extraction error');
-    }
-  }
-}
-```
-
-## Integration with Existing Systems
-
-The service integrates seamlessly with the existing extraction infrastructure:
-
-- **Uses TabManager**: Leverages the existing TabManager for actual extraction
-- **Background Messaging**: Communicates with background script using the established messaging protocol
-- **Consistent Types**: Returns TabContent in the same format as existing hooks
-- **Cache Integration**: Works with the existing content caching system
-
-## API Reference
-
-### ExtractionService
-
-Main service class for content extraction.
-
-#### Methods
-
-- `extractCurrentTab(options?): Promise<TabContent>` - Extract current tab content
-- `extractTabs(tabIds, options?): Promise<BatchExtractionResult>` - Extract multiple tabs
-
-### ServiceExtractionOptions
-
-Configuration options for extraction:
-
-```typescript
-interface ServiceExtractionOptions extends ExtractionOptions {
-  forceRefresh?: boolean; // Ignore cache
-  mode?: ExtractionMode; // DEFUDDLE, SELECTION, or RAW
-  maxRetries?: number; // Retry attempts (default: 2)
-  retryDelay?: number; // Delay between retries (default: 1000ms)
-}
-```
-
-### ExtractionResult
-
-Individual extraction result:
-
-```typescript
-interface ExtractionResult {
-  success: boolean;
-  content?: TabContent; // If successful
-  error?: string; // If failed
-  tabId: number;
-}
-```
-
-### BatchExtractionResult
-
-Batch extraction results with statistics:
-
-```typescript
-interface BatchExtractionResult {
-  results: ExtractionResult[];
-  totalTabs: number;
-  successCount: number;
-  failureCount: number;
-  successRate: number; // Percentage
-}
-```
+Use `createExtractionService()` in Vitest suites to inject a mocked message
+transport or to assert retry behaviour.  The default singleton
+(`defaultExtractionService`) is exported for convenience when dependency
+injection is not required.

--- a/src/services/session/README.md
+++ b/src/services/session/README.md
@@ -1,140 +1,62 @@
-# Session Service
+# SessionService
 
-The SessionService provides centralized management for browser tab sessions with unique session identification, isolation, and lifecycle management.
+`SessionService` centralises how the sidebar generates and manages per-tab
+sessions.  It wraps the Zustand `useSessionStore` so callers do not manipulate
+store internals directly and provides helpers for deterministic session keys.
 
-## Features
+## Basics
 
-- **Deterministic session keys**: Generate consistent session keys from tabId + URL
-- **URL normalization**: Handle URL variations for consistent session identification
-- **Session isolation**: Keep different tabs/URLs completely separate
-- **Lifecycle management**: Clean up sessions when tabs close or become inactive
-- **Integration ready**: Works with existing conversation state management
-
-## Basic Usage
-
-```typescript
+```ts
 import { sessionService } from '@services/session';
 
-// Generate a session key
-const sessionKey = sessionService.getSessionKey(123, 'https://example.com/page');
-console.log(sessionKey); // "tab_123:https://example.com/page"
-
-// Get full session info
-const sessionInfo = sessionService.getSessionInfo(123, 'https://example.com/page');
-console.log(sessionInfo);
-// {
-//   sessionKey: "tab_123:https://example.com/page",
-//   tabId: 123,
-//   url: "https://example.com/page",
-//   normalizedUrl: "https://example.com/page"
-// }
-
-// Check if session exists
-const exists = sessionService.hasSession(123, 'https://example.com/page');
-
-// Clear a specific session
-sessionService.clearSession(sessionKey);
-
-// Clear all sessions for a tab
-sessionService.clearTabSessions(123);
+const key = sessionService.getSessionKey(tabId, url);
+const info = sessionService.getSessionInfo(tabId, url);
+const hasSession = sessionService.hasSession(tabId, url);
 ```
 
-## Advanced Usage
+* Session keys follow the format `tab_<tabId>:<normalisedUrl>`.
+* URL normalisation keeps query parameters by default, strips hashes, and leaves
+  non-HTTP(S) schemes untouched.
+* `getSessionInfo()` returns the key plus the original and normalised URLs.
 
-```typescript
-import { SessionService, createSessionService } from '@services/session';
+## Store interaction
 
-// Create custom service with configuration
-const customService = createSessionService({
-  includeQuery: false, // Ignore query parameters
-  includeHash: true, // Include hash fragments
-});
+The service proxies to `useSessionStore` and related helpers:
 
-// Custom URL normalization
-const advancedService = new SessionService({
-  normalizeUrlFn: url => {
-    // Custom logic for your use case
-    return url.toLowerCase().replace(/\/+$/, '');
-  },
-});
+* `clearSession(sessionKey)` and `clearTabSessions(tabId)` delegate to the store’s
+  cleanup actions.
+* `getAllSessionKeys()` / `getTabSessions(tabId)` expose read-only snapshots for
+  diagnostics.
+* `cleanupInactiveSessions({ maxAge, maxSessions })` prunes old sessions using the
+  timestamps maintained by the store (`lastAccessedAt`).
 
-// Session comparison
-const isSame = sessionService.isSameSession(
-  'https://example.com/page',
-  'https://example.com/page#section'
-); // true (hash ignored by default)
+All methods catch store errors and rethrow descriptive exceptions so UI code can
+surface meaningful messages.
 
-// Cleanup inactive sessions
-const cleaned = sessionService.cleanupInactiveSessions({
-  maxAge: 60 * 60 * 1000, // 1 hour
-  maxSessions: 50, // Keep max 50 sessions
-});
-console.log(`Cleaned up ${cleaned} sessions`);
+## Configuration
+
+Constructing a service manually allows for alternative normalisation rules:
+
+```ts
+import { SessionService } from '@services/session';
+
+const service = new SessionService({ includeHash: true });
 ```
 
-## Session Key Format
+Options:
 
-Session keys follow the format: `tab_{tabId}:{normalizedUrl}`
+| Option | Default | Description |
+| ------ | ------- | ----------- |
+| `includeQuery` | `true` | Keep `?query` when building session keys |
+| `includeHash` | `false` | Include `#hash` fragments |
+| `normalizeUrlFn` | internal helper | Custom URL normaliser |
 
-Examples:
+## Parsing helpers
 
-- `tab_123:https://example.com/page`
-- `tab_456:https://docs.google.com/document/d/abc123`
-- `tab_789:https://github.com/user/repo/issues?state=open`
+`parseSessionKey(key)` returns `{ tabId, url }` or `null` if the key is malformed
+(using the shared helper from `@shared/utils/urlNormalizer`).
 
-## URL Normalization Rules
+## Testing
 
-By default, URLs are normalized as follows:
-
-1. **Trailing slashes removed**: `https://example.com/page/` → `https://example.com/page`
-2. **Query parameters preserved**: `https://example.com/page?id=123` → `https://example.com/page?id=123`
-3. **Hash fragments ignored**: `https://example.com/page#section` → `https://example.com/page`
-
-This ensures that:
-
-- Same logical pages share sessions
-- Different content (query params) gets separate sessions
-- Navigation within a page (hash changes) maintains the same session
-
-## Integration with Existing Hooks
-
-The SessionService integrates seamlessly with existing session management:
-
-```typescript
-// In your components
-import { sessionService } from '@services/session';
-import { useSessionManager } from '@hooks/useSessionManager';
-
-function MyComponent() {
-  const { currentSession } = useSessionManager();
-
-  if (currentSession) {
-    const sessionKey = sessionService.getSessionKey(currentSession.tabId, currentSession.url);
-
-    // Use sessionKey for your logic
-  }
-}
-```
-
-## Configuration Options
-
-```typescript
-interface SessionServiceConfig {
-  /** Include query parameters in session key (default: true) */
-  includeQuery?: boolean;
-
-  /** Include hash fragments in session key (default: false) */
-  includeHash?: boolean;
-
-  /** Custom URL normalization function */
-  normalizeUrlFn?: (url: string) => string;
-}
-```
-
-## Best Practices
-
-1. **Use the default service** for most cases: `sessionService`
-2. **Create custom services** only when you need different normalization rules
-3. **Clean up sessions periodically** to prevent memory leaks
-4. **Handle edge cases** like invalid URLs or tab closure events
-5. **Test session isolation** to ensure data doesn't leak between sessions
+The module exports `createSessionService(config?)` so tests can obtain isolated
+instances with mocked stores or alternate normalisation strategies.

--- a/src/shared/README.md
+++ b/src/shared/README.md
@@ -1,26 +1,15 @@
-# Shared Module
+# Shared helpers
 
-Cross‑cutting utilities shared across modules.
-
-## Structure
-
-```
-shared/
-└─ utils/
-   ├─ restrictedUrls.ts  # Centralized check for restricted pages (chrome://, etc.)
-   └─ urlNormalizer.ts   # Normalizes URLs for session keys
-```
+`src/shared/` contains cross-cutting utilities that do not warrant a full
+service.  They are side-effect free and reused by both the background worker and
+the UI.
 
 ## Utilities
 
-### `restrictedUrls.ts`
+| File | Description |
+| ---- | ----------- |
+| `utils/restrictedUrls.ts` | Guards for URLs that the extension should not inject into (`chrome://`, `chrome-extension://`, Web Store, file scheme, …) |
+| `utils/urlNormalizer.ts` | `normalizeUrl`, `createSessionKey`, and `parseSessionKey` helpers used by stores and services |
 
-- `isRestrictedUrl(url)` — true for chrome://, file:// (unless permitted), web stores, etc.
-- `isValidTabUrl(url)` — helper guard used by background and UI filters
-
-### `urlNormalizer.ts`
-
-- `normalizeUrl(url)` — removes trailing slash, keeps query, drops hash
-- `createSessionKey(tabId, url)` / `parseSessionKey(key)` — deterministic session keys
-
-All functions are pure and side‑effect free.
+The functions export plain booleans/strings so they can be used anywhere without
+bringing in browser-specific dependencies.

--- a/src/sidebar/styles/README.md
+++ b/src/sidebar/styles/README.md
@@ -1,329 +1,44 @@
-# CSS Architecture Guide
+# Sidebar styles
 
-## Overview
+The sidebar uses CSS `@layer` to control the cascade inside the Shadow DOM.
+All styles live under `src/sidebar/styles/` and are imported from
+`index.css` in a fixed order so component overrides stay predictable.
 
-This directory contains the modular CSS architecture for the AI Browser Sidebar extension. The styles are organized using a layered approach with CSS `@layer` for predictable cascade control and minimal `!important` usage.
-
-## Directory Structure
+## Directory
 
 ```
 styles/
-├── 0-foundation/   # Variables, animations, reset
-├── 1-base/        # Core styles and typography
-├── 2-layout/      # Layout components
-├── 3-components/  # Reusable UI components
-├── 4-features/    # Feature-specific styles
-└── index.css      # Main entry with layer definitions
+├─ 0-foundation/   # reset.css, variables.css, animations.css
+├─ 1-base/         # base layout + typography
+├─ 2-layout/       # structural rules (resize handles, scrollbars)
+├─ 3-components/   # shared component styles (buttons, markdown, tooltips, …)
+├─ 4-features/     # feature-specific overrides (tab mentions, search sources)
+└─ index.css       # defines @layer order and imports the files above
 ```
 
-## CSS Layers Architecture
-
-The styles implement CSS `@layer` for cascade control:
-
-```css
-@layer reset, foundation, base, layout, components, features, utilities;
-```
-
-### Layer Order (lowest to highest priority):
-
-1. **reset** - Browser normalization
-2. **foundation** - CSS variables and animations
-3. **base** - Core styles and typography
-4. **layout** - Structural components
-5. **components** - Reusable UI components
-6. **features** - Feature-specific styles
-7. **utilities** - Utility classes (only layer allowed to use `!important`)
-
-## CSS Guidelines
-
-### 1. Avoid `!important`
-
-**❌ Don't:**
-
-```css
-.message-bubble {
-  background: #2f67de !important;
-  color: white !important;
-}
-```
-
-**✅ Do:**
-
-```css
-/* Use CSS variables */
-.message-bubble {
-  background: var(--msg-user-bg);
-  color: var(--msg-user-text);
-}
-
-/* Or use higher specificity */
-.ai-sidebar-container .message-bubble {
-  background: var(--msg-user-bg);
-  color: var(--msg-user-text);
-}
-```
-
-### 2. Use Component-Namespaced Variables
-
-Variables are organized with component prefixes in `0-foundation/variables.css`:
-
-```css
-/* Message Bubbles */
---msg-user-bg: #2f67de;
---msg-user-text: white;
-
-/* Chat Input */
---input-bg: transparent;
---input-text: #e5e7eb;
-
-/* Modal */
---modal-bg: #1a1a1a;
---modal-text: #d4d4d4;
-```
-
-### 3. Specificity Management
-
-Use the `.ai-sidebar-container` parent selector for natural specificity:
-
-```css
-/* Base style */
-.chat-input {
-  padding: 4px;
-}
-
-/* Override with higher specificity instead of !important */
-.ai-sidebar-container .chat-input {
-  padding: 8px;
-}
-```
-
-### 4. Layer Usage
-
-Place styles in appropriate layers:
-
-```css
-/* Foundation layer for variables */
-@layer foundation {
-  .ai-sidebar-container {
-    --primary-color: #3b82f6;
-  }
-}
-
-/* Component layer for UI components */
-@layer components {
-  .button {
-    background: var(--primary-color);
-  }
-}
-
-/* Utilities layer for override classes */
-@layer utilities {
-  .text-center {
-    text-align: center !important; /* OK in utilities layer */
-  }
-}
-```
-
-### 5. File Organization
-
-- **0-foundation/**: Variables, animations, reset styles
-- **1-base/**: Typography, base element styles
-- **2-layout/**: Page structure, sidebars, grids
-- **3-components/**: Buttons, inputs, cards, modals
-- **4-features/**: Complex feature-specific styles
-
-### 6. Naming Conventions
-
-Use BEM-inspired naming with component prefixes:
-
-```css
-/* Component */
-.chat-input {
-}
-
-/* Component element */
-.chat-input__textarea {
-}
-
-/* Component modifier */
-.chat-input--loading {
-}
-
-/* Component state */
-.chat-input.is-focused {
-}
-```
-
-## Adding New Styles
-
-### 1. Create Component File
-
-Place in appropriate directory:
-
-```bash
-# For a new UI component
-src/sidebar/styles/3-components/new-component.css
-
-# For a feature
-src/sidebar/styles/4-features/new-feature.css
-```
-
-### 2. Add Variables
-
-Define component-specific variables in `0-foundation/variables.css`:
-
-```css
-/* New Component */
---new-component-bg: #1a1a1a;
---new-component-text: #e5e7eb;
---new-component-border: 1px solid rgba(75, 85, 99, 0.3);
-```
-
-### 3. Import in index.css
-
-Add import in the correct section with appropriate layer:
-
-```css
-/* Components Layer */
-@import './3-components/new-component.css' layer(components);
-```
-
-### 4. Write Styles Without !important
-
-```css
-/* new-component.css */
-.ai-sidebar-container .new-component {
-  background: var(--new-component-bg);
-  color: var(--new-component-text);
-  border: var(--new-component-border);
-}
-```
-
-## Refactoring Legacy Styles
-
-When refactoring styles with `!important`:
-
-1. **Check if it's a utility class** - Keep `!important` in utilities
-2. **Use CSS variables** - Replace hard-coded values
-3. **Increase specificity** - Add parent selectors
-4. **Use layers** - Let cascade order handle priority
-5. **Test thoroughly** - Ensure visual appearance unchanged
-
-## Current Status
-
-- Layered architecture in place across foundation/base/layout/components/features
-- `!important` is restricted to the `utilities` layer only
-- Component‑scoped variables live in `0-foundation/variables.css`
-
-## Testing CSS Changes
-
-After modifying CSS:
-
-1. **Build the project**: `npm run build`
-2. **Check for visual regressions**: Load extension and verify UI
-3. **Test responsive behavior**: Resize sidebar
-4. **Verify dark/light themes**: If applicable
-5. **Check component states**: Hover, focus, active states
-
-## Performance Best Practices
-
-1. **Use CSS variables** for dynamic values
-2. **Avoid deep nesting** (max 3 levels)
-3. **Minimize redundant selectors**
-4. **Group related properties**
-5. **Use shorthand where appropriate**
-6. **Leverage CSS containment** for isolated components
-
-## Migration Status
-
-### Completed Refactoring
-
-- ✅ reset.css - New reset layer created
-- ✅ variables.css - Component namespaces added
-- ✅ index.css - CSS layers implemented
-- ✅ message-bubbles.css - 80 → 0 `!important`
-- ✅ chat-input.css - 48 → 0 `!important`
-- ✅ fullscreen-modal.css - 31 → 0 `!important`
-- ✅ markdown-content.css - 23 → 0 `!important`
-- ✅ typography.css - Moved to layers (utilities preserved)
-- ✅ tab-content-item.css - 15 → 0 `!important`
-
-### Ongoing Cleanup
-
-- Continue migrating any residual `!important` declarations into utilities
-- Consolidate repeated colors into variables
-- Keep specificity shallow (prefer parent scoping to `!important`)
-
-## Common Patterns
-
-### Transparent Backgrounds
-
-```css
-.component {
-  background: var(--input-bg, transparent);
-  background-color: var(--input-bg, transparent);
-}
-```
-
-### Focus States
-
-```css
-.input:focus {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--focus-ring);
-}
-```
-
-### Hover Effects
-
-```css
-.button {
-  transition: all 0.2s ease;
-}
-
-.button:hover {
-  background: var(--hover-overlay);
-  transform: scale(1.05);
-}
-```
-
-## Troubleshooting
-
-### Styles Not Applying
-
-1. Check layer order in index.css
-2. Verify import path is correct
-3. Ensure parent selector specificity
-4. Check for typos in class names
-
-### Unexpected Cascade
-
-1. Review layer definitions
-2. Check specificity calculations
-3. Look for conflicting `!important`
-4. Verify variable inheritance
-
-### Performance Issues
-
-1. Reduce complex selectors
-2. Minimize reflows/repaints
-3. Use CSS containment
-4. Optimize animations
-
-## Contributing
-
-When adding or modifying CSS:
-
-1. Follow the guidelines above
-2. Maintain the layered architecture
-3. Add variables for new components
-4. Document complex styles
-5. Test across different states
-6. Avoid adding `!important` except in utilities layer
-
-## Resources
-
-- [CSS Layers MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer)
-- [CSS Custom Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)
-- [CSS Specificity Calculator](https://specificity.keegan.st/)
-- [BEM Methodology](http://getbem.com/)
+`index.css` declares the layer order as `reset, foundation, base, layout,
+components, features, utilities`.  Only the first six are populated today; the
+`utilities` layer is reserved for future helper classes (and is the only place
+where `!important` is permitted).
+
+## Guidelines
+
+* Keep selectors scoped to `.ai-sidebar-container` or component-specific class
+  names—Shadow DOM isolation prevents leaks, but explicit scoping keeps styles
+  easy to reason about.
+* Prefer CSS variables defined in `0-foundation/variables.css`.  Introduce new
+  variables there when adding components.
+* Add new component files under `3-components/` and import them from
+  `index.css` alphabetically within the layer to avoid merge conflicts.
+* Feature-specific combinations (e.g. multi-tab tab list) belong under
+  `4-features/` so they can override component defaults without using
+  `!important`.
+* When bringing in third-party styles (KaTeX, Prism, …) import them within the
+  appropriate layer so they honour the cascade.
+
+## Development workflow
+
+1. Add the CSS file in the correct subdirectory.
+2. Import it from `index.css` with the matching `layer(...)` qualifier.
+3. Run `npm run dev`—Vite will update the Shadow DOM styles without reloading the
+   page.

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -1,40 +1,60 @@
-# Types Module
+# Shared types
 
-Centralized, shared TypeScript definitions used across the extension.
+This directory collects TypeScript definitions consumed by both the background
+worker and the React UI.  Keeping them central avoids circular dependencies and
+ensures all modules speak the same protocol.
 
-## Files
+## Contents
 
+| File | Description |
+| ---- | ----------- |
+| `apiKeys.ts` | API key metadata, masking helpers, and provider enums |
+| `chat.ts` | Chat message shapes and streaming delta types |
+| `conversation.ts` | Conversation/session models persisted in stores |
+| `extraction.ts` | `ExtractionMode`, `ExtractionOptions`, and `ExtractedContent` contracts |
+| `manifest.ts` | Subset of MV3 manifest typings used at runtime |
+| `messages.ts` | Typed message envelopes, payload unions, and helpers (`createMessage`, `isValidMessage`) |
+| `providers.ts` | Provider interfaces (`AIProvider`, `StreamChunk`, capability flags) |
+| `settings.ts` | Settings store schema and helpers |
+| `storage.ts` | Chrome storage schema definitions |
+| `tabs.ts` | Tab metadata used across services/background |
+| `index.ts` | Barrel export |
+| `css.d.ts`, `prism-components.d.ts`, `turndown-plugin-gfm.d.ts`, `node-shim.d.ts`, `openai-shim.d.ts` | Module shims for third-party packages |
+
+## Messaging helpers
+
+`messages.ts` defines the canonical message envelope:
+
+```ts
+interface Message<T = unknown> {
+  id: string;
+  type: MessageType;
+  source: MessageSource;
+  target: MessageTarget;
+  payload?: T;
+  timestamp: number;
+}
 ```
-types/
-├─ apiKeys.ts        # API key shapes + format helpers
-├─ chat.ts           # Chat message + stream chunk types
-├─ conversation.ts   # Conversation/session models
-├─ extraction.ts     # ExtractedContent, ExtractionMode, option defaults/guards
-├─ messages.ts       # Message protocol (types, payloads, createMessage)
-├─ providers.ts      # Provider/engine contracts
-├─ settings.ts       # Settings state + models list shapes
-├─ storage.ts        # Storage schema + serialization helpers
-├─ tabs.ts           # Tab info/state
-├─ manifest.ts       # Manifest types
-├─ index.ts          # Barrel exports
-└─ *.d.ts            # CSS/Prism/GFM module declarations
-```
 
-## Messaging (high‑level)
+The file exports guards (`isValidMessage`) and factories (`createMessage`) used by
+all messaging layers (`content`, `extension`, `services`).  Payload unions cover
+requests such as `TOGGLE_SIDEBAR`, `GET_ALL_TABS`, `EXTRACT_TAB_CONTENT`,
+`PROXY_REQUEST`, and the associated responses.
 
-`messages.ts` defines the union of message types and payloads and exposes a `createMessage` factory. Selected message ids used today:
+## Extraction types
 
-- `TOGGLE_SIDEBAR`, `CLOSE_SIDEBAR`
-- `GET_TAB_ID`, `GET_TAB_INFO`, `GET_ALL_TABS`
-- `EXTRACT_TAB_CONTENT` ↔ `CONTENT_EXTRACTED`
-- `CLEANUP_TAB_CACHE`, `PROXY_REQUEST`, `PING`/`PONG`, `ERROR`
+`extraction.ts` enumerates the supported modes (`READABILITY`, `RAW`, `DEFUDDLE`,
+`SELECTION`), validates options, and exposes helper guards so the orchestrator
+and background worker can share the same runtime checks.
 
-All messages include an id, timestamp, source, and target.
+## Provider contracts
 
-## Extraction
+`providers.ts` normalises provider behaviour by defining `AIProvider`,
+`ProviderChatMessage`, `StreamChunk`, and `ProviderCapabilities`.  Engines extend
+these interfaces, while the sidebar consumes them through `ChatService`.
 
-`extraction.ts` contains `ExtractedContent`, `ExtractionMode` (`readability | raw | defuddle | selection`), defaults, and runtime validators/normalizers for options and results.
+## Adding new types
 
-## Providers & Engines
-
-`providers.ts` defines the normalized provider interface (messages in, streamed deltas out) and capability flags consumed by the UI.
+1. Create the definition in this directory.
+2. Export it from `index.ts` so path aliases (`@/types/...`) can pick it up.
+3. Update any relevant tests under `tests/unit` to cover the new contract.


### PR DESCRIPTION
## Summary
- rewrite the `src/README.md` overview to reflect the current module layout and cross-cutting workflow
- refresh module-level READMEs (content, extension, services, transport, etc.) with accurate responsibilities and extension-specific guidance
- expand service documentation for extraction, key management, sessions, and styling so contributors can rely on the latest behaviour

## Testing
- npm run lint *(fails: repository still lacks an ESLint flat config)*

------
https://chatgpt.com/codex/tasks/task_e_68cbb6b44560832cb37bf202f3fcf9fd